### PR TITLE
chore: react to rate limiting on GlobalStandard

### DIFF
--- a/workshop/dotnet/infra/main.bicep
+++ b/workshop/dotnet/infra/main.bicep
@@ -340,7 +340,7 @@ module storageContribRoleApi 'core/security/role.bicep' = {
 }
 
 module dataScientistRole 'core/security/subscription-role.bicep' = {
-  name: 'data-scientist-role'
+  name: 'data-scientist-role-${resourceToken}'
   params: {
     principalId: api.outputs.SERVICE_API_PRINCIPAL_ID
     roleDefinitionId: 'f6c7c914-8db3-469d-8ca1-694a8f32e121' // Azure ML Data Scientist

--- a/workshop/pre-reqs/infra/main.bicep
+++ b/workshop/pre-reqs/infra/main.bicep
@@ -6,7 +6,8 @@ targetScope = 'subscription'
 param environmentName string
 
 @description('Primary location for all resources')
-@allowed([ 'centralus', 'eastus2', 'eastasia', 'westus', 'westeurope', 'westus2', 'australiaeast', 'eastus', 'francecentral', 'japaneast', 'nortcentralus', 'swedencentral', 'switzerlandnorth', 'uksouth' ])
+// Locations that support gpt-4o
+@allowed([ 'australiaeast', 'brazilsouth', 'canadaeast', 'eastus', 'eastus2', 'francecentral', 'germanywestcentral', 'japaneast', 'koreacentral', 'northcentralus', 'norwayeast', 'polandcentral', 'switzerlandnorth', 'southafricanorth','southcentralus', 'southindia', 'spaincentral', 'swedencentral', 'switzerlandnorth', 'uaenorth', 'uksouth', 'westeurope', 'westus', 'westus3' ])
 param location string
 
 @description('Tags to apply to the resources')

--- a/workshop/pre-reqs/infra/modules/cognitive-services.bicep
+++ b/workshop/pre-reqs/infra/modules/cognitive-services.bicep
@@ -15,7 +15,7 @@ param gptModelDeploymentName string = 'gpt-4o'
 @description('Capacity of the GPT model deployment')
 param gptModelCapacity int = 1
 @description('SKU name for the GPT model deployment')
-param gptModelSkuName string = 'GlobalStandard'
+param gptModelSkuName string = 'Standard'
 @description('Format of the GPT model')
 param gptModelFormat string = 'OpenAI'
 @description('Version of the GPT model')


### PR DESCRIPTION
Use a Standard model, not Global Standard because of rate limiting. Also specify the updated list of locations that support gpt-4o.

Also reduce the risk of deployment errors when you deploy multiple stacks at the same time due to role naming issues. This is a low risk but could occur if someone deploys multiple stacks at once.